### PR TITLE
HITZ V3: Post-Exhaustion Security Model with Timelock

### DIFF
--- a/packages/api/contract/V3_SECURITY_ROADMAP.md
+++ b/packages/api/contract/V3_SECURITY_ROADMAP.md
@@ -1,0 +1,31 @@
+# V3 Security Model Roadmap
+
+## Overview
+The V3 Security Model introduces anti-arbitrage protections to the Skyhitz staking system.
+
+## Phase 1: 24-Hour Staking Timelock (PR #15)
+
+### Problem: Atomic Batch Arbitrage
+On the Stellar network, multiple operations can be bundled into a single atomic transaction. Without a timelock, an attacker could:
+1. **Deposit** a large amount of capital
+2. **Claim** rewards or manipulate state within the same transaction
+3. **Withdraw** immediately with zero market exposure
+
+This allows risk-free arbitrage that extracts value from the protocol.
+
+### Solution: Time-Based Commitment
+- Every stake deposit sets `unlock_time = now + 86400` (24 hours)
+- `unstake()` enforces: if `now < unlock_time`, transaction panics
+- Top-up deposits reset the timer for the entire position
+
+### Security Properties
+- **Intentionality**: Forces genuine capital commitment
+- **Market Exposure**: 24 hours of price risk discourages hit-and-run attacks
+- **Dusting Protection**: Timer resets prevent circumvention via tiny deposits
+
+## Phase 2: Admin Recovery Tools (PR #16) - Planned
+- `admin_set_total_minted()` for supply cap corrections
+- `force_oracle_price()` for emergency price overrides
+
+## Phase 3: Post-Exhaustion Enhancements (PR #17) - Planned
+- Final economic model tuning for sustainability

--- a/packages/api/contract/src/lib.rs
+++ b/packages/api/contract/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-//! Skyhitz Core V2 - Soroban Smart Contract (Post-Exhaustion Model)
+//! Skyhitz Core V3 - Soroban Smart Contract (Post-Exhaustion Model + Security Hardened)
 //!
 //! Purpose: Record user actions for music entries, manage HITZ staking,
 //! and distribute rewards from treasury to entry reward pools.
@@ -121,6 +121,15 @@ pub struct Entry {
 pub struct ArtistEquityClaim {
     pub equity_bps: u32,    // Artist's equity share in basis points (100 = 1%)
     pub claimed: i128,      // HITZ already claimed by this artist
+}
+
+/// User stake data with 24-hour timelock to prevent arbitrage
+/// Timelock resets on each deposit to prevent flash-loan style exploits
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserStake {
+    pub amount: i128,       // Staked amount in stroops
+    pub unlock_time: u64,   // Timestamp when stake can be withdrawn
 }
 
 #[contract]
@@ -411,12 +420,25 @@ impl SkyhitzCore {
             safe_transfer(&e, &hitz_token, &caller, &contract_addr, &fee, "stake deposit");
 
             // Record stake (stake = fee, simple 1:1)
+            // SECURITY: 24-hour timelock to prevent arbitrage attacks
             let stake_key = DataKey::Stake((entry_id.clone(), caller.clone()));
-            let current_stake: i128 = e.storage().persistent().get(&stake_key).unwrap_or(0);
-            let new_stake = current_stake
+            
+            // Load or initialize UserStake struct
+            let mut user_stake = e.storage().persistent()
+                .get::<DataKey, UserStake>(&stake_key)
+                .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
+            
+            let new_stake = user_stake.amount
                 .checked_add(fee)
                 .unwrap_or_else(|| panic!("User stake overflow for entry"));
-            e.storage().persistent().set(&stake_key, &new_stake);
+            
+            // TIMELOCK: Reset unlock time to 24 hours from now on every deposit
+            // This prevents flash-loan style arbitrage by ensuring intentionality
+            let now = e.ledger().timestamp();
+            user_stake.amount = new_stake;
+            user_stake.unlock_time = now.saturating_add(86_400); // 24 hours in seconds
+            
+            e.storage().persistent().set(&stake_key, &user_stake);
             e.storage().persistent().extend_ttl(&stake_key, STORAGE_LIFETIME_THRESHOLD, STORAGE_BUMP_AMOUNT);
 
             let total_key = DataKey::StakeTotal(entry_id.clone());
@@ -495,7 +517,19 @@ impl SkyhitzCore {
     /// Get user's stake for an entry
     pub fn get_stake(e: Env, entry_id: String, owner: Address) -> i128 {
         let key = DataKey::Stake((entry_id, owner));
-        e.storage().persistent().get(&key).unwrap_or(0)
+        let user_stake: UserStake = e.storage().persistent()
+            .get::<DataKey, UserStake>(&key)
+            .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
+        user_stake.amount
+    }
+
+    /// Get unlock time for user's stake (0 if no stake or can unstake immediately)
+    pub fn get_stake_unlock_time(e: Env, entry_id: String, owner: Address) -> u64 {
+        let key = DataKey::Stake((entry_id, owner));
+        let user_stake: UserStake = e.storage().persistent()
+            .get::<DataKey, UserStake>(&key)
+            .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
+        user_stake.unlock_time
     }
 
     /// Get total stake for an entry
@@ -921,7 +955,10 @@ impl SkyhitzCore {
 
         // Get user's stake
         let stake_key = DataKey::Stake((entry_id.clone(), claimer.clone()));
-        let user_stake: i128 = e.storage().persistent().get(&stake_key).unwrap_or(0);
+        let user_stake_data: UserStake = e.storage().persistent()
+            .get::<DataKey, UserStake>(&stake_key)
+            .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
+        let user_stake = user_stake_data.amount;
 
         if user_stake == 0 {
             panic!("No stake in this entry");
@@ -1007,6 +1044,7 @@ impl SkyhitzCore {
     /// - If user has no stake
     /// - If amount exceeds user's stake
     /// - If amount <= 0
+    /// - If stake is still timelocked (24-hour lock after deposit)
     pub fn unstake(e: Env, entry_id: String, caller: Address, amount: i128) -> i128 {
         caller.require_auth();
         
@@ -1015,27 +1053,41 @@ impl SkyhitzCore {
             panic!("Amount must be positive");
         }
         
-        // Get user's current stake
+        // Get user's current stake (now a UserStake struct with timelock)
         let stake_key = DataKey::Stake((entry_id.clone(), caller.clone()));
-        let user_stake: i128 = e.storage().persistent().get(&stake_key).unwrap_or(0);
+        let user_stake: UserStake = e.storage().persistent()
+            .get::<DataKey, UserStake>(&stake_key)
+            .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
         
-        if user_stake == 0 {
+        if user_stake.amount == 0 {
             panic!("No stake in this entry");
         }
         
-        if amount > user_stake {
+        if amount > user_stake.amount {
             panic!("Amount exceeds stake");
+        }
+        
+        // SECURITY: Enforce 24-hour timelock
+        // This prevents flash-loan style arbitrage attacks
+        let now = e.ledger().timestamp();
+        if now < user_stake.unlock_time {
+            panic!("Stake locked until timestamp: {}. Current time: {}", user_stake.unlock_time, now);
         }
         
         e.storage().persistent().extend_ttl(&stake_key, STORAGE_LIFETIME_THRESHOLD, STORAGE_BUMP_AMOUNT);
         
         // Update user's stake
-        let new_user_stake = user_stake.saturating_sub(amount);
-        if new_user_stake == 0 {
+        let new_user_amount = user_stake.amount.saturating_sub(amount);
+        if new_user_amount == 0 {
             // Remove stake entry if going to zero
             e.storage().persistent().remove(&stake_key);
         } else {
-            e.storage().persistent().set(&stake_key, &new_user_stake);
+            // Preserve unlock_time (don't reset on partial unstake)
+            let updated_stake = UserStake {
+                amount: new_user_amount,
+                unlock_time: user_stake.unlock_time,
+            };
+            e.storage().persistent().set(&stake_key, &updated_stake);
         }
         
         // Update total stake
@@ -1065,7 +1117,10 @@ impl SkyhitzCore {
     /// Get claimable HITZ rewards for a staker (accounts for artist equity)
     pub fn get_claimable_rewards(e: Env, entry_id: String, user: Address) -> i128 {
         let stake_key = DataKey::Stake((entry_id.clone(), user.clone()));
-        let user_stake: i128 = e.storage().persistent().get(&stake_key).unwrap_or(0);
+        let user_stake_data: UserStake = e.storage().persistent()
+            .get::<DataKey, UserStake>(&stake_key)
+            .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
+        let user_stake = user_stake_data.amount;
 
         if user_stake == 0 {
             return 0;
@@ -1369,11 +1424,20 @@ impl SkyhitzCore {
         let mut migrated_stake_total: i128 = 0;
         for user in stakers.iter() {
             let from_stake_key = DataKey::Stake((from_id.clone(), user.clone()));
-            if let Some(stake_amount) = e.storage().persistent().get::<DataKey, i128>(&from_stake_key) {
-                // Move stake to new entry
+            if let Some(from_user_stake) = e.storage().persistent().get::<DataKey, UserStake>(&from_stake_key) {
+                let stake_amount = from_user_stake.amount;
+                // Move stake to new entry, preserving timelock
                 let into_stake_key = DataKey::Stake((into_id.clone(), user.clone()));
-                let current_into_stake: i128 = e.storage().persistent().get(&into_stake_key).unwrap_or(0);
-                e.storage().persistent().set(&into_stake_key, &current_into_stake.saturating_add(stake_amount));
+                let current_into_stake = e.storage().persistent()
+                    .get::<DataKey, UserStake>(&into_stake_key)
+                    .unwrap_or(UserStake { amount: 0, unlock_time: 0 });
+                
+                // Merge stakes: add amounts, take the later unlock_time
+                let new_stake = UserStake {
+                    amount: current_into_stake.amount.saturating_add(stake_amount),
+                    unlock_time: core::cmp::max(current_into_stake.unlock_time, from_user_stake.unlock_time),
+                };
+                e.storage().persistent().set(&into_stake_key, &new_stake);
                 
                 // Also migrate claimed amounts
                 let from_claimed_key = DataKey::Claimed((from_id.clone(), user.clone()));
@@ -1502,8 +1566,9 @@ impl SkyhitzCore {
             
             for user in stakers.iter() {
                 let stake_key = DataKey::Stake((entry_id.clone(), user.clone()));
-                if let Some(stake_amount) = e.storage().persistent().get::<DataKey, i128>(&stake_key) {
-                    // SECURITY FIX H2: Return stake to user with verification
+                if let Some(user_stake) = e.storage().persistent().get::<DataKey, UserStake>(&stake_key) {
+                    let stake_amount = user_stake.amount;
+                    // SECURITY FIX H2: Return stake to user with verification (admin bypasses timelock)
                     safe_transfer(&e, &hitz_token, &contract_addr, &user, &stake_amount, "stake refund");
                     returned_total = returned_total.saturating_add(stake_amount);
                     
@@ -1661,3 +1726,5 @@ fn get_action_params(e: &Env, kind: &Symbol, amount: Option<i128>) -> (i128, i12
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod test_atomic_attack;

--- a/packages/api/contract/src/test_atomic_attack.rs
+++ b/packages/api/contract/src/test_atomic_attack.rs
@@ -1,0 +1,94 @@
+use super::*;
+use soroban_sdk::{Env, Address, String, symbol_short, token, testutils::{Address as _, Ledger}};
+use core::panic;
+
+// We need std for catch_unwind in tests
+extern crate std; 
+
+#[test]
+fn test_atomic_arbitrage_protection() {
+    let e = Env::default();
+    e.mock_all_auths_allowing_non_root_auth();
+
+    // Setup Phase (Self-contained setup logic)
+    // Timelock is 86400 seconds.
+    // Atomic attack tries to enter and exit in the same ledger (0 elapsed time).
+
+    let admin = Address::generate(&e);
+    let treasury = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    // Use SAC instances for both HITZ and XLM
+    let hitz_token = e.register_stellar_asset_contract_v2(issuer.clone());
+    let xlm_token = e.register_stellar_asset_contract_v2(issuer.clone());
+
+    e.ledger().with_mut(|li| {
+        li.protocol_version = 22;
+        li.min_persistent_entry_ttl = 4096;
+        li.min_temp_entry_ttl = 4096;
+        li.max_entry_ttl = 31_536_000;
+    });
+    
+    // Register contract
+    let contract_id = e.register(SkyhitzCore, ());
+    let client = SkyhitzCoreClient::new(&e, &contract_id);
+    
+    // Give HITZ to contract for staking and to attacker for fees
+    let hitz_admin = token::StellarAssetClient::new(&e, &hitz_token.address());
+    hitz_admin.mint(&contract_id, &10_000_000_000i128);
+    
+    // CRITICAL: Set contract as HITZ token admin (required for the contract to work)
+    hitz_admin.set_admin(&contract_id);
+
+    // Initialize contract
+    client.init(
+        &admin, 
+        &treasury, 
+        &hitz_token.address(), 
+        &1_000_000i128 // base fee in HITZ stroops
+    );
+
+    let attacker = Address::generate(&e);
+    let attack_amount = 1_000_000_000_000i128; // Large capital
+
+    // Give attacker HITZ for staking (post-exhaustion model takes HITZ fees)
+    hitz_admin.mint(&attacker, &attack_amount);
+
+    // The "Atomic" Transaction Simulation
+
+    let entry_id = String::from_str(&e, "entry_1");
+    client.create_entry(&entry_id); // Admin creates entry
+
+    // TIME = T (1000)
+    e.ledger().with_mut(|li| li.timestamp = 1000); 
+
+    // OPERATION 1: Invest Large Amount (Stake)
+    // This calls record_action -> takes HITZ fee -> sets 24h lock
+    client.record_action(
+        &attacker,
+        &entry_id,
+        &symbol_short!("invest"), 
+        &Some(attack_amount) // investing in HITZ
+    );
+    
+    // Check stake exists
+    let stake = client.get_stake(&entry_id, &attacker);
+    assert!(stake > 0, "Stake should exist");
+
+    // OPERATION 2: Unstake Immediately (Exploit Attempt)
+    // Time is STILL T (1000)
+    // logic: "unstake" checks if (now < unlock_time). 
+    // record_action set unlock_time = 1000 + 86400 = 87400.
+    // check: 1000 < 87400? YES. Should Panic.
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.unstake(&entry_id, &attacker, &stake);
+    }));
+
+    match result {
+        Ok(_) => panic!("TEST FAILED: Atomic arbitrage was ALLOWED! Timelock did not activate."),
+        Err(_) => {
+            // Panic caught successfully - timelock is working
+        }
+    }
+}

--- a/packages/api/contract/src/tests.rs
+++ b/packages/api/contract/src/tests.rs
@@ -735,6 +735,9 @@ fn test_unstake_partial() {
 
     let user_balance_before = hitz_balance_client.balance(&user);
 
+    // Advance ledger time past 24-hour timelock (86400 seconds)
+    e.ledger().with_mut(|li| li.timestamp = 86_401);
+
     // Unstake 10M stroops (1/3 of 30M stake)
     let unstaked = client.unstake(&entry_id, &user, &10_000_000i128);
     assert_eq!(unstaked, 10_000_000);
@@ -775,6 +778,9 @@ fn test_unstake_full() {
 
     let user_stake_before = client.get_stake(&entry_id, &user);
     assert_eq!(user_stake_before, 30_000_000); // 3 HITZ stake
+
+    // Advance ledger time past 24-hour timelock (86400 seconds)
+    e.ledger().with_mut(|li| li.timestamp = 86_401);
 
     // Unstake ALL HITZ
     let unstaked = client.unstake(&entry_id, &user, &30_000_000i128);
@@ -902,6 +908,9 @@ fn test_unstake_multiple_users() {
     let total_stake_before = client.get_stake_total(&entry_id);
     assert_eq!(total_stake_before, 150_000_000);
 
+    // Advance ledger time past 24-hour timelock (86400 seconds)
+    e.ledger().with_mut(|li| li.timestamp = 86_401);
+
     // User1 unstakes half of their stake (25M stroops)
     client.unstake(&entry_id, &user, &25_000_000i128);
 
@@ -934,6 +943,9 @@ fn test_unstake_then_reinvest() {
     // POST-EXHAUSTION: User invests 3 HITZ (30M stroops), stake = fee (1:1)
     client.record_action(&user, &entry_id, &symbol_short!("invest"), &Some(30_000_000i128));
     assert_eq!(client.get_stake(&entry_id, &user), 30_000_000); // 3 HITZ stake
+
+    // Advance ledger time past 24-hour timelock (86400 seconds)
+    e.ledger().with_mut(|li| li.timestamp = 86_401);
 
     // User unstakes all
     client.unstake(&entry_id, &user, &30_000_000i128);
@@ -1498,3 +1510,88 @@ fn test_incremental_artist_claims() {
     assert_eq!(total_claimed, 100_000_000);
 }
 
+// ========================================================================
+// V3 Security Model: 24-Hour Timelock Tests
+// ========================================================================
+
+#[test]
+#[should_panic(expected = "Stake locked until timestamp:")]
+fn test_timelock_prevents_early_unstake() {
+    let (e, admin, treasury, user, hitz_addr, contract_id) = setup_test_with_contract();
+
+    let client = SkyhitzCoreClient::new(&e, &contract_id);
+
+    let hitz_admin = token::StellarAssetClient::new(&e, &hitz_addr);
+    hitz_admin.mint(&contract_id, &10_000_000_000i128);
+    hitz_admin.mint(&user, &10_000_000_000i128);
+
+    client.init(&admin, &treasury, &hitz_addr, &100_000i128);
+
+    let entry_id = String::from_str(&e, "song123");
+    client.create_entry(&entry_id);
+
+    // User stakes at time 0
+    client.record_action(&user, &entry_id, &symbol_short!("invest"), &Some(30_000_000i128));
+    
+    // Try to unstake at time 100 (before 86400) - should panic
+    e.ledger().with_mut(|li| li.timestamp = 100);
+    client.unstake(&entry_id, &user, &15_000_000i128);
+}
+
+#[test]
+fn test_timelock_allows_unstake_after_24h() {
+    let (e, admin, treasury, user, hitz_addr, contract_id) = setup_test_with_contract();
+
+    let client = SkyhitzCoreClient::new(&e, &contract_id);
+
+    let hitz_admin = token::StellarAssetClient::new(&e, &hitz_addr);
+    hitz_admin.mint(&contract_id, &10_000_000_000i128);
+    hitz_admin.mint(&user, &10_000_000_000i128);
+
+    client.init(&admin, &treasury, &hitz_addr, &100_000i128);
+
+    let entry_id = String::from_str(&e, "song123");
+    client.create_entry(&entry_id);
+
+    // Stake at time 0, unlock at 86400
+    client.record_action(&user, &entry_id, &symbol_short!("invest"), &Some(30_000_000i128));
+    let stake = client.get_stake(&entry_id, &user);
+    
+    // Verify unlock time is set to 86400
+    let unlock_time = client.get_stake_unlock_time(&entry_id, &user);
+    assert_eq!(unlock_time, 86_400);
+    
+    // Advance to exactly 86400 - should work
+    e.ledger().with_mut(|li| li.timestamp = 86_400);
+    let unstaked = client.unstake(&entry_id, &user, &stake);
+    assert_eq!(unstaked, stake);
+}
+
+#[test]
+fn test_timelock_reset_on_topup() {
+    let (e, admin, treasury, user, hitz_addr, contract_id) = setup_test_with_contract();
+
+    let client = SkyhitzCoreClient::new(&e, &contract_id);
+
+    let hitz_admin = token::StellarAssetClient::new(&e, &hitz_addr);
+    hitz_admin.mint(&contract_id, &10_000_000_000i128);
+    hitz_admin.mint(&user, &10_000_000_000i128);
+
+    client.init(&admin, &treasury, &hitz_addr, &100_000i128);
+
+    let entry_id = String::from_str(&e, "song123");
+    client.create_entry(&entry_id);
+
+    // First stake at time 0, unlock at 86400
+    client.record_action(&user, &entry_id, &symbol_short!("invest"), &Some(30_000_000i128));
+    let unlock1 = client.get_stake_unlock_time(&entry_id, &user);
+    assert_eq!(unlock1, 86_400);
+    
+    // Advance time to 50000 (still locked)
+    e.ledger().with_mut(|li| li.timestamp = 50_000);
+    
+    // Top up stake - this should reset unlock to 50000 + 86400 = 136400
+    client.record_action(&user, &entry_id, &symbol_short!("invest"), &Some(30_000_000i128));
+    let unlock2 = client.get_stake_unlock_time(&entry_id, &user);
+    assert_eq!(unlock2, 136_400); // 50000 + 86400
+}


### PR DESCRIPTION
## Part of V3 Post-Exhaustion Security Model (PR 1 of 3)

### 📘 [**Read the Full V3 Security Roadmap**](https://github.com/AdamBuzzard/skyhitz/blob/feat/pr14-staking-timelock-clean/packages/api/contract/V3_SECURITY_ROADMAP.md)

---

### Phase I: Anti-Arbitrage (Staking Timelock)

This PR implements the first line of defense for the **V3 Security Model**: a mandatory **24-hour resting period** for all staked capital.

### 🛡️ Why This Is Critical: "Atomic Batch Attacks"
On the Stellar network, multiple operations can be bundled into a single atomic transaction. Without a timelock, an attacker can theoretically:
1.  **Deposit** a large amount of capital.
2.  **Manipulate** contract state (e.g., claim rewards or skew a pool) within the same transaction or ledger close.
3.  **Withdraw** the capital immediately.

This allows for **Risk-Free Arbitrage**: extracting value from the protocol without ever exposing funds to market volatility. 

**The Solution**: By enforcing a `now + 86,400s` lock on every deposit, we ensure that entering a position requires a genuine commitment of time and capital exposure, mathematically eliminating zero-risk arbitrage loops.

---

### Core Technical Changes
- **State Structure**: Replaced raw `i128` stake with `UserStake { amount, unlock_time }`.
- **Strict Enforcement**: `unstake()` reverts if `ledger.timestamp < unlock_time`.
- **Top-Up Security**: Adding *any* amount to a stake resets the 24h timer for the *entire* position (preventing "dusting" bypasses).
- **Visibility**: New view function `get_stake_unlock_time()` for clear UI feedback.

---

### Verification
- **53/53 Tests Pass** (`cargo test --features testutils`)
- **[NEW] Atomic Attack Simulation**: Added `src/test_atomic_attack.rs` which explicitly attempts to stake and unstake in the *same ledger*.
  - **Result**: The contract correctly **PANICS**, proving the vector is blocked.
- **Negative Cases**: Verified early unstake attempts fail.
- **Edge Cases**: Partial unstakes preserve lock; Top-ups extend lock.
